### PR TITLE
fix add_check_digit to take zero-padded and non-zero-padded GTINs

### DIFF
--- a/gtin_validator.py
+++ b/gtin_validator.py
@@ -20,54 +20,50 @@ the method defined at http://www.gs1.org/barcodes/support/check_digit_calculator
 
 """
 
-def is_valid_GTIN(code):
-  """ Validates any GTIN-8, GTIN-12, GTIN-13 or GTIN-14 code. """
-  cleaned_code = _clean(code)
 
-  return _is_valid_code(cleaned_code)
+def is_valid_GTIN(code):
+    """ Validates any GTIN-8, GTIN-12, GTIN-13 or GTIN-14 code. """
+    cleaned_code = _clean(code)
+
+    return _is_valid_code(cleaned_code)
 
 
 def add_check_digit(code):
-  """ Adds a check digit to the end of code. """
-  cleaned_code = _clean(code, fill=13)
-  return cleaned_code + str(_gtin_checksum(cleaned_code))
+    """ Adds a check digit to the end of code. """
+    cleaned_code = _clean(code, fill=13)
+    return cleaned_code + str(_gtin_checksum(cleaned_code))
 
 
 def _clean(code, fill=14):
-  if isinstance(code,(int,long)):
+    if isinstance(code, (int, long)):
         return str(code).zfill(fill)
-  elif isinstance(code,basestring):
-        return code.replace("-","").strip().zfill(fill)
-  else:
+    elif isinstance(code, basestring):
+        return code.replace("-", "").strip().zfill(fill)
+    else:
         raise TypeError("Expected string or integer type as input parameter")
 
 
 def _is_valid_code(code):
-  if not code.isdigit():
+    if not code.isdigit():
         return False
-  elif len(code) not in (8, 12, 13, 14, 18):
+    elif len(code) not in (8, 12, 13, 14, 18):
         return False
-  else:
+    else:
         return _is_gtin_checksum_valid(code)
 
 
 def _gtin_checksum(code):
-  total = 0
+    total = 0
 
-  for (i, c) in enumerate(code):
+    for (i, c) in enumerate(code):
         if i % 2 == 1:
-          total = total + int(c)
+            total = total + int(c)
         else:
-          total = total + (3 * int(c))
+            total = total + (3 * int(c))
 
-  check_digit = (10 - (total % 10)) % 10
-  return check_digit
+    check_digit = (10 - (total % 10)) % 10
+    return check_digit
 
 
 def _is_gtin_checksum_valid(code):
     return int(code[-1]) == _gtin_checksum(code[:-1])
-
-
-
-
-

--- a/gtin_validator_test.py
+++ b/gtin_validator_test.py
@@ -3,117 +3,111 @@
 import unittest
 from gtin_validator import *
 
+
 class GTINValidatorTest(unittest.TestCase):
 
-  def test_incorrect_length_string(self):
+    def test_incorrect_length_string(self):
         self.assertFalse(is_valid_GTIN("1234567"))
 
-  def test_incorrect_length_number(self):
+    def test_incorrect_length_number(self):
         self.assertFalse(is_valid_GTIN(12345678910))
 
-  def test_correct_length_string_with_spaces(self):
+    def test_correct_length_string_with_spaces(self):
         self.assertFalse(is_valid_GTIN(" 1234567891 "))
 
-  def test_correct_length_string_with_dashes(self):
+    def test_correct_length_string_with_dashes(self):
         self.assertFalse(is_valid_GTIN("123-456-7890"))
 
-  def test_alphanumeric_string(self):
+    def test_alphanumeric_string(self):
         self.assertFalse(is_valid_GTIN("98795147A"))
 
-
-  def test_valid_gtin8_string_no_leading_zeros(self):
+    def test_valid_gtin8_string_no_leading_zeros(self):
         self.assertTrue(is_valid_GTIN("98795147"))
 
-  def test_valid_gtin8_string_with_leading_zeros(self):
+    def test_valid_gtin8_string_with_leading_zeros(self):
         self.assertTrue(is_valid_GTIN("0000098795147"))
 
-  def test_valid_gtin8_string_with_leading_zeros_and_dashes(self):
+    def test_valid_gtin8_string_with_leading_zeros_and_dashes(self):
         self.assertTrue(is_valid_GTIN("000-0-098-79514-7"))
 
-  def test_valid_gtin8_number(self):
+    def test_valid_gtin8_number(self):
         self.assertTrue(is_valid_GTIN(98795147))
 
-  def test_gtin8_invalid_check_digit(self):
+    def test_gtin8_invalid_check_digit(self):
         self.assertFalse(is_valid_GTIN("98795145"))
 
-  
-  def test_valid_gtin12_string_no_leading_zeros(self):
+    def test_valid_gtin12_string_no_leading_zeros(self):
         self.assertTrue(is_valid_GTIN("951753852654"))
 
-  def test_valid_gtin12_string_with_leading_zeros(self):
+    def test_valid_gtin12_string_with_leading_zeros(self):
         self.assertTrue(is_valid_GTIN("0951753852654"))
 
-  def test_valid_gtin12_string_with_leading_zeros_and_dashes(self):
+    def test_valid_gtin12_string_with_leading_zeros_and_dashes(self):
         self.assertTrue(is_valid_GTIN("095-1-753-85265-4"))
 
-  def test_valid_gtin12_number(self):
+    def test_valid_gtin12_number(self):
         self.assertTrue(is_valid_GTIN(951753852654))
 
-  def test_gtin12_invalid_check_digit(self):
+    def test_gtin12_invalid_check_digit(self):
         self.assertFalse(is_valid_GTIN("951753852651"))
-  
-  
-  def test_valid_gtin13_string(self):
+
+    def test_valid_gtin13_string(self):
         self.assertTrue(is_valid_GTIN("9780552133265"))
 
-  def test_valid_gtin13_string_with_dashes(self):
+    def test_valid_gtin13_string_with_dashes(self):
         self.assertTrue(is_valid_GTIN("978-0-552-13326-5"))
 
-  def test_valid_gtin13_number(self):
+    def test_valid_gtin13_number(self):
         self.assertTrue(is_valid_GTIN(9780552133265))
 
-  def test_gtin13_invalid_check_digit(self):
+    def test_gtin13_invalid_check_digit(self):
         self.assertFalse(is_valid_GTIN("9780552133262"))
 
-
-  def test_valid_gtin14_string(self):
+    def test_valid_gtin14_string(self):
         self.assertTrue(is_valid_GTIN("95135725845679"))
 
-  def test_valid_gtin14_number(self):
+    def test_valid_gtin14_number(self):
         self.assertTrue(is_valid_GTIN(95135725845679))
 
-  def test_gtin14_invalid_check_digit(self):
+    def test_gtin14_invalid_check_digit(self):
         self.assertFalse(is_valid_GTIN("95135725845672"))
 
-  def test_checksum_multiple_of_ten(self):
+    def test_checksum_multiple_of_ten(self):
         self.assertTrue(is_valid_GTIN("7896085864520"))
 
-
-  def test_add_check_digit_gtin14_string(self):
+    def test_add_check_digit_gtin14_string(self):
         self.assertEquals(add_check_digit('9513572584567'), '95135725845679')
 
-  def test_add_check_digit_gtin14_number(self):
+    def test_add_check_digit_gtin14_number(self):
         self.assertEquals(add_check_digit(9513572584567), '95135725845679')
 
-  def test_add_check_digit_gtin13_string(self):
+    def test_add_check_digit_gtin13_string(self):
         self.assertEquals(add_check_digit('978055213326'), '09780552133265')
 
-  def test_add_check_digit_gtin13_number(self):
+    def test_add_check_digit_gtin13_number(self):
         self.assertEquals(add_check_digit(978055213326), '09780552133265')
 
-  def test_add_check_digit_gtin13_leading_zeros(self):
+    def test_add_check_digit_gtin13_leading_zeros(self):
         self.assertEquals(add_check_digit('0978055213326'), '09780552133265')
 
-  def test_add_check_digit_gtin12_string(self):
+    def test_add_check_digit_gtin12_string(self):
         self.assertEquals(add_check_digit('95175385265'), '00951753852654')
 
-  def test_add_check_digit_gtin12_number(self):
+    def test_add_check_digit_gtin12_number(self):
         self.assertEquals(add_check_digit(95175385265), '00951753852654')
 
-  def test_add_check_digit_gtin12_leading_zeros(self):
+    def test_add_check_digit_gtin12_leading_zeros(self):
         self.assertEquals(add_check_digit('0095175385265'), '00951753852654')
 
-  def test_add_check_digit_gtin8_string(self):
+    def test_add_check_digit_gtin8_string(self):
         self.assertEquals(add_check_digit('9879514'), '00000098795147')
 
-  def test_add_check_digit_gtin8_number(self):
+    def test_add_check_digit_gtin8_number(self):
         self.assertEquals(add_check_digit(9879514), '00000098795147')
 
-  def test_add_check_digit_gtin8_leading_zeros(self):
+    def test_add_check_digit_gtin8_leading_zeros(self):
         self.assertEquals(add_check_digit('0000009879514'), '00000098795147')
 
 
-
 if __name__ == '__main__':
-  unittest.main()
-
+    unittest.main()


### PR DESCRIPTION
`add_check_digit` was a bit buggy when you gave it zero-padded GTINs or GTINs that were not 13 characters long. This fixes it to handle all combinations of zero-padded and non-zero-padded GTINs of different lengths.
