### PR TITLE
Ignore non-digit chars in gtin codes

### DIFF
--- a/gtin/validator.py
+++ b/gtin/validator.py
@@ -39,9 +39,15 @@ def _clean(code):
     if isinstance(code, six.integer_types):
         return str(code)
     elif isinstance(code, six.string_types):
-        return "".join(c for c in code if c.isalnum())
-    else:
+        if '--' not in code:
+            code = code.replace("-", "").replace(" ", "").strip()
+
+    try:
+       int(code)
+    except ValueError:
         raise TypeError("Expected string or integer type as input parameter")
+
+    return code
 
 
 def _is_valid_code(code):

--- a/gtin/validator.py
+++ b/gtin/validator.py
@@ -35,11 +35,11 @@ def add_check_digit(code):
     return cleaned_code + str(_gtin_checksum(cleaned_code))
 
 
-def _clean(code, fill=14):
+def _clean(code):
     if isinstance(code, six.integer_types):
         return str(code)
     elif isinstance(code, six.string_types):
-        return code.replace("-", "").strip()
+        return "".join(c for c in code if c.isalnum())
     else:
         raise TypeError("Expected string or integer type as input parameter")
 
@@ -47,7 +47,7 @@ def _clean(code, fill=14):
 def _is_valid_code(code):
     if not code.isdigit():
         return False
-    elif len(code) not in (8, 12, 13, 14, 18):
+    elif len(code) not in (8, 12, 13, 14):
         return False
     else:
         return _is_gtin_checksum_valid(code.zfill(14))

--- a/gtin/validator_test.py
+++ b/gtin/validator_test.py
@@ -22,7 +22,12 @@ class GTINValidatorTest(unittest.TestCase):
         self.assertFalse(is_valid_GTIN("123-456-7890"))
 
     def test_alphanumeric_string(self):
-        self.assertFalse(is_valid_GTIN("98795147A"))
+        with self.assertRaises(TypeError):
+            is_valid_GTIN("98795148A")
+
+    def test_multiple_dashes_string(self):
+        with self.assertRaises(TypeError):
+            is_valid_GTIN("9517---53-85-2654")
 
     def test_correct_string_with_spaces(self):
         self.assertTrue(is_valid_GTIN(" 987 951 47 "))

--- a/gtin/validator_test.py
+++ b/gtin/validator_test.py
@@ -24,6 +24,9 @@ class GTINValidatorTest(unittest.TestCase):
     def test_alphanumeric_string(self):
         self.assertFalse(is_valid_GTIN("98795147A"))
 
+    def test_correct_string_with_spaces(self):
+        self.assertTrue(is_valid_GTIN(" 987 951 47 "))
+
     def test_valid_gtin8_string_no_leading_zeros(self):
         self.assertTrue(is_valid_GTIN("98795147"))
 


### PR DESCRIPTION
It's just a more general handling than just for `-` char. 